### PR TITLE
Mail/mail 861

### DIFF
--- a/scripts/include.sh/build-dep.sh
+++ b/scripts/include.sh/build-dep.sh
@@ -330,7 +330,20 @@ get_prebuilt_dep()
   
   installed_version="`defaults read "$installed_versions_path" "$name" 2>/dev/null`"
   if test ! -d "$scriptpath/../Externals/$name" ; then
-    installed_version=
+    echo "$name is not in Externals. Checking built products dir"
+
+    if test -f "${BUILT_PRODUCTS_DIR}/${name}.a" ; then
+      echo "Found product in built products dir, using that version. The version number of that"
+      echo "version is unknown, it is your responsability to ensure that it is up to date and is"
+      echo "configured properly with any required headers copied to $BUILT_PRODUCTS_DIR"
+
+      # Mark the version as up to date, even though the true version number is not known
+      installed_version="`defaults read "$versions_path" "$name" 2>/dev/null`"
+    else
+      # There is no version in BUILT_PRODUCTS_DIR so clear installed_version in order to 
+      # download a new copy
+      installed_version=
+    fi
   fi
   if test "x$installed_version" = x ; then
     installed_version="none"

--- a/src/async/imap/MCIMAPAsyncConnection.cpp
+++ b/src/async/imap/MCIMAPAsyncConnection.cpp
@@ -221,6 +221,16 @@ bool IMAPAsyncConnection::isCheckCertificateEnabled()
     return mSession->isCheckCertificateEnabled();
 }
 
+void IMAPAsyncConnection::setEnableMalformedAddressHack(bool enabled)
+{
+    mSession->setEnableMalformedAddressHack(enabled);
+}
+
+bool IMAPAsyncConnection::enableMalformedAddressHack()
+{
+    return mSession->enableMalformedAddressHack();
+}
+
 void IMAPAsyncConnection::setVoIPEnabled(bool enabled)
 {
     mSession->setVoIPEnabled(enabled);

--- a/src/async/imap/MCIMAPAsyncConnection.h
+++ b/src/async/imap/MCIMAPAsyncConnection.h
@@ -66,6 +66,9 @@ namespace mailcore {
         
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
+
+        virtual void setEnableMalformedAddressHack(bool enabled);
+        virtual bool enableMalformedAddressHack();
         
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();

--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -78,6 +78,10 @@ namespace mailcore {
         
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
+
+        virtual void setEnableMalformedAddressHack(bool enabled);
+        virtual bool enableMalformedAddressHack();
+        virtual bool supportsMalformedAddressHack();
         
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();
@@ -207,6 +211,7 @@ namespace mailcore {
         ConnectionType mConnectionType;
         bool mCheckCertificateEnabled;
         bool mVoIPEnabled;
+        bool mEnableMalformedAddressHack;
         IMAPNamespace * mDefaultNamespace;
         time_t mTimeout;
         bool mAllowsFolderConcurrentAccessEnabled;

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -529,6 +529,19 @@ bool IMAPSession::isCheckCertificateEnabled()
     return mCheckCertificateEnabled;
 }
 
+void IMAPSession::setEnableMalformedAddressHack(bool enabled)
+{
+#ifdef LIBETPAN_HAS_MALFORMED_ADDRESS_HACK
+    malformedAddressWorkaroundEnabled = enabled;
+    mailimap_set_malformed_address_workaround_enabled(mImap, enabled);
+#endif
+}
+
+bool IMAPSession::enableMalformedAddressHack()
+{
+    return malformedAddressWorkaroundEnabled;
+}
+
 void IMAPSession::setVoIPEnabled(bool enabled)
 {
     mVoIPEnabled = enabled;
@@ -616,6 +629,9 @@ void IMAPSession::setup()
     mailimap_set_timeout(mImap, timeout());
     mailimap_set_progress_callback(mImap, body_progress, IMAPSession::items_progress, this);
     mailimap_set_logger(mImap, logger, this);
+#ifdef LIBETPAN_HAS_MALFORMED_ADDRESS_HACK
+    mailimap_set_malformed_address_workaround_enabled(mImap, malformedAddressWorkaroundEnabled);
+#endif
 }
 
 void IMAPSession::unsetup()

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -55,6 +55,9 @@ namespace mailcore {
         
         virtual void setCheckCertificateEnabled(bool enabled);
         virtual bool isCheckCertificateEnabled();
+
+        virtual void setEnableMalformedAddressHack(bool enabled);
+        virtual bool enableMalformedAddressHack();
         
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();
@@ -276,6 +279,7 @@ namespace mailcore {
         bool mRamblerRuServer;
         bool mHermesServer;
         bool mQipServer;
+        bool malformedAddressWorkaroundEnabled;
         
         unsigned int mLastFetchedSequenceNumber;
         String * mCurrentFolder;

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -105,6 +105,12 @@
 /** Does the server support QRESYNC */
 @property (nonatomic, assign, readonly) BOOL isQResyncEnabled;
 
+/** Enables or disables the malformed address hack for this session */
+@property (nonatomic, assign) BOOL enableMalformedAddressHack;
+
+/** Returns true if malformed address hack support was complied, false if not */
+@property (nonatomic, readonly) BOOL supportsMalformedAddressHack;
+
 /**
  Display name of the Gmail user. It will be nil if it's not a Gmail server.
 

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -119,6 +119,21 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return MCO_TO_OBJC(_session->defaultNamespace());
 }
 
+- (void) setEnableMalformedAddressHack:(BOOL)enabled
+{
+    _session->setEnableMalformedAddressHack(enabled);
+}
+
+- (BOOL)enableMalformedAddressHack
+{
+    return _session->enableMalformedAddressHack();
+}
+
+- (BOOL)supportsMalformedAddressHack
+{
+    return _session->supportsMalformedAddressHack();
+}
+
 - (MCOIMAPIdentity *) clientIdentity
 {
     return MCO_OBJC_BRIDGE_GET(clientIdentity);


### PR DESCRIPTION
I'm pretty sure that Steve already approved this PR, but that was in the other Mailcore repo. Since this mess got a bit confused I'm giving it back for review.

This updates mailcore to make it possible to use a libetpan that we build ourselves (rather than downloading) while still maintaining compatibility with the old build system, and it also adds accessors to enable/query the hack that I added to libetpan from Mailcore (since libetpan isn't exposed in Mailcore world).

Once this is merged I can update the other PR to pull in this version again. 